### PR TITLE
chore(docs): PR notes for AdminPanel fix

### DIFF
--- a/docs/PR_ADMINPANEL_NOTES.md
+++ b/docs/PR_ADMINPANEL_NOTES.md
@@ -1,0 +1,19 @@
+# PR: AdminPanel JSX fix
+
+This PR contains a small, docs-only commit to open a pull request for the recent AdminPanel JSX fix.
+
+Summary of changes already merged to `main`:
+
+- Fixed truncated JSX in `Onchainweb/src/components/AdminPanel.jsx` so the project builds.
+- Replaced non-exported `getAdminPermissions` usage with `getAdminByEmail` from `adminService`.
+- Performed a clean install and verified `npm run build` succeeds.
+
+This file is intentionally documentation-only to create a comfortable PR that does not affect the app runtime.
+
+Build verification:
+- `node -v`: v24.11.1
+- `npm -v`: 11.6.2
+- `cd Onchainweb && npm run build` completed successfully and produced `dist/`.
+
+Requested next steps:
+- Review and merge if desired, or leave changes already on `main` as-is.


### PR DESCRIPTION
Docs-only PR to surface the AdminPanel JSX build fix. This change is documentation-only and does not modify runtime code. Build passed locally: cd Onchainweb && npm run build.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 4 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fddefi0175-netizen%2FSnipe-%2Fpull%2F108&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->