### PR TITLE
Fix frontend route mounting and service export regressions

### DIFF
--- a/Onchainweb/src/App.jsx
+++ b/Onchainweb/src/App.jsx
@@ -1,44 +1,34 @@
 
 // React automatic JSX runtime in use — default React import not required
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
-import { SpeedInsights } from '@vercel/speed-insights/react';
-import { UniversalWalletProvider } from './lib/walletConnect';
+import { Route, Routes } from 'react-router-dom';
 import Header from './components/Header';
 import Footer from './components/Footer';
 import Dashboard from './components/Dashboard';
 import Trade from './components/Trade';
 import Wallet from './components/Wallet';
 import NotFound from './components/NotFound';
-import ErrorBoundary from './components/ErrorBoundary';
 
 // Small debug helper to mark intentionally unused imports as used
 const _debugUnused_App = (ctx) => {
   // Keep minimal runtime impact in development only
   if (typeof console !== 'undefined' && process?.env?.NODE_ENV !== 'production') console.debug('app-unused', ctx);
 };
-_debugUnused_App({ Router, Route, Routes, SpeedInsights, UniversalWalletProvider, Header, Footer, Dashboard, Trade, Wallet, NotFound, ErrorBoundary });
+_debugUnused_App({ Route, Routes, Header, Footer, Dashboard, Trade, Wallet, NotFound });
 
 function App() {
   return (
-    <ErrorBoundary>
-      <UniversalWalletProvider>
-        <Router>
-          <div className="app-container">
-            <Header />
-            <main className="main-content">
-              <Routes>
-                <Route path="/" element={<Dashboard />} />
-                <Route path="/trade" element={<Trade />} />
-                <Route path="/wallet" element={<Wallet />} />
-                <Route path="*" element={<NotFound />} />
-              </Routes>
-            </main>
-            <Footer />
-          </div>
-        </Router>
-      </UniversalWalletProvider>
-      <SpeedInsights />
-    </ErrorBoundary>
+    <div className="app-container">
+      <Header />
+      <main className="main-content">
+        <Routes>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/trade" element={<Trade />} />
+          <Route path="/wallet" element={<Wallet />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </main>
+      <Footer />
+    </div>
   );
 }
 

--- a/Onchainweb/src/main.jsx
+++ b/Onchainweb/src/main.jsx
@@ -105,7 +105,7 @@ if (!envCheck.valid && import.meta.env.PROD) {
               <ConsentBanner />
               <Suspense fallback={<LoadingSpinner />}>
                 <Routes>
-                  <Route path={ROUTES.HOME} element={<MainApp />} />
+                  <Route path={`${ROUTES.HOME}*`} element={<MainApp />} />
                   {/* Admin route - always registered, but shows disabled message if feature not enabled */}
                   <Route
                     path={ROUTES.ADMIN}

--- a/Onchainweb/src/services/index.js
+++ b/Onchainweb/src/services/index.js
@@ -5,7 +5,7 @@
 export * from '../lib/firebase.js';
 
 // Legacy API Service (for backward compatibility)
-export * from './api.service.js';
+export * from '../lib/api.js';
 
 // TURN Server Service
 export * from './turn.service.js';


### PR DESCRIPTION
### Motivation
- Ensure app routes and service exports work correctly so pages like `/trade` and `/wallet` resolve through the intended layout without changing application behavior.
- Remove duplicated/global providers and nested routers that can cause navigation/provider conflicts at runtime.
- Restore a valid service barrel export to prevent import-time failures from `services/index.js`.

### Description
- Change top-level app mount to allow nested routes by updating `Route path={ROUTES.HOME}` to `Route path={`${ROUTES.HOME}*`}` in `Onchainweb/src/main.jsx`.
- Simplify `Onchainweb/src/App.jsx` by removing nested `BrowserRouter`, `UniversalWalletProvider`, `ErrorBoundary`, and duplicated `SpeedInsights`, leaving `App.jsx` as the internal route/layout container only and cleaning unused imports.
- Fix the services export by replacing the missing `./api.service.js` export with the existing legacy stub at `../lib/api.js` in `Onchainweb/src/services/index.js`.
- Committed the changes as a focused stability fix without altering product behavior.

### Testing
- Ran `npm install` which failed with a `403 Forbidden` from the npm registry, so dependency-based build and tests could not be executed.
- Ran `npm run build` which was blocked due to the same registry `403` during install and therefore did not complete.
- Performed static inspection and local file checks (`git diff`, file edits, and `node --check` attempts), noting `node --check` cannot validate `.jsx` files directly; these static checks confirmed the intended code changes.
- Changes were committed successfully and a PR was created.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953087cfb8832e89cecf84a5765175)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued · ✅ 2 no changes — [View all](https://hub.continue.dev/inbox/pr/ddefi0175-netizen/Snipe-/144?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->